### PR TITLE
Add benchmarks for redis multi

### DIFF
--- a/benchmarks/get.js
+++ b/benchmarks/get.js
@@ -1,5 +1,5 @@
 module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
-	// node_redis get
+    // node_redis get
     async () => {
         console.time('node_redis get');
 
@@ -13,7 +13,23 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('node_redis get');
     },
 
-	// ioredis get
+    // node_redis get with multi
+    async () => {
+        console.time('node_redis get with multi');
+
+        let len = TEST_LEN;
+        let multi = nodeRedis.multi();
+        while (len--) {
+            multi.get(`node_redis:${type}`);
+        }
+        await (new Promise(resolve => {
+            multi.exec(resolve);
+        }));
+
+        console.timeEnd('node_redis get with multi');
+    },
+
+    // ioredis get
     async () => {
         console.time('ioredis get');
 
@@ -25,7 +41,7 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('ioredis get');
     },
 
-	// ioredis get with pipeline
+    // ioredis get with pipeline
     async () => {
         console.time('ioredis get with pipeline');
 
@@ -37,5 +53,19 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         await (pipeline.exec());
 
         console.timeEnd('ioredis get with pipeline');
+    },
+
+    // ioredis get with multi
+    async () => {
+        console.time('ioredis get with multi');
+
+        let len = TEST_LEN;
+        let multi = ioredis.multi();
+        while (len--) {
+            multi.get(`ioredis:${type}`);
+        }
+        await (multi.exec());
+
+        console.timeEnd('ioredis get with multi');
     }
 ]);

--- a/benchmarks/hgetall.js
+++ b/benchmarks/hgetall.js
@@ -1,5 +1,5 @@
 module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
-	// node_redis hgetall
+    // node_redis hgetall
     async () => {
         console.time('node_redis hgetall');
 
@@ -13,7 +13,23 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('node_redis hgetall');
     },
 
-	// ioredis hgetall
+    // node_redis hgetall with multi
+    async () => {
+        console.time('node_redis hgetall with multi');
+
+        let len = TEST_LEN;
+        let multi = nodeRedis.multi();
+        while (len--) {
+            multi.hgetall(`node_redis:${type}`);
+        }
+        await (new Promise(resolve => {
+            multi.exec(resolve);
+        }));
+
+        console.timeEnd('node_redis hgetall with multi');
+    },
+
+    // ioredis hgetall
     async () => {
         console.time('ioredis hgetall');
 
@@ -25,7 +41,7 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('ioredis hgetall');
     },
 
-	// ioredis hgetall with pipeline
+    // ioredis hgetall with pipeline
     async () => {
         console.time('ioredis hgetall with pipeline');
 
@@ -37,5 +53,19 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         await (pipeline.exec());
 
         console.timeEnd('ioredis hgetall with pipeline');
+    },
+
+    // ioredis hgetall with multi
+    async () => {
+        console.time('ioredis hgetall with multi');
+
+        let len = TEST_LEN;
+        let multi = ioredis.multi();
+        while (len--) {
+            multi.hgetall(`ioredis:${type}`);
+        }
+        await (multi.exec());
+
+        console.timeEnd('ioredis hgetall with multi');
     }
 ]);

--- a/benchmarks/hmset.js
+++ b/benchmarks/hmset.js
@@ -1,5 +1,5 @@
 module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
-	// node_redis hmset
+    // node_redis hmset
     async () => {
         console.time('node_redis hmset');
 
@@ -13,7 +13,23 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('node_redis hmset');
     },
 
-	// ioredis hmset
+    // node_redis hmset with multi
+    async () => {
+        console.time('node_redis hmset with multi');
+
+        let len = TEST_LEN;
+        let multi = nodeRedis.multi();
+        while (len--) {
+            multi.hmset(`node_redis:${type}`, TEST_DATA.hash);
+        }
+        await (new Promise(resolve => {
+            multi.exec(resolve);
+        }));
+
+        console.timeEnd('node_redis hmset with multi');
+    },
+
+    // ioredis hmset
     async () => {
         console.time('ioredis hmset');
 
@@ -25,7 +41,7 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('ioredis hmset');
     },
 
-	// ioredis hmset with pipeline
+    // ioredis hmset with pipeline
     async () => {
         console.time('ioredis hmset with pipeline');
 
@@ -37,5 +53,19 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         await (pipeline.exec());
 
         console.timeEnd('ioredis hmset with pipeline');
+    },
+
+    // ioredis hmset with multi
+    async () => {
+        console.time('ioredis hmset with multi');
+
+        let len = TEST_LEN;
+        let multi = ioredis.multi();
+        while (len--) {
+            multi.hmset(`ioredis:${type}`, TEST_DATA.hash);
+        }
+        await (multi.exec());
+
+        console.timeEnd('ioredis hmset with multi');
     }
 ]);

--- a/benchmarks/incr.js
+++ b/benchmarks/incr.js
@@ -1,5 +1,5 @@
 module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
-	// node_redis incr
+    // node_redis incr
     async () => {
         console.time('node_redis incr');
 
@@ -13,29 +13,59 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('node_redis incr');
     },
 
-	// ioredis incr
+    // node_redis incr with multi
+    async () => {
+        console.time('node_redis incr with multi');
+
+        let len = TEST_LEN;
+        let multi = nodeRedis.multi();
+        while (len--) {
+            multi.incr(`node_redis:${type}`);
+        }
+        await (new Promise(resolve => {
+            multi.exec(resolve);
+        }));
+
+        console.timeEnd('node_redis incr with multi');
+    },
+
+    // ioredis incr
     async () => {
         console.time('ioredis incr');
 
         let len = TEST_LEN;
         while (len--) {
-            await (ioredis.get(`ioredis:${type}`));
+            await (ioredis.incr(`ioredis:${type}`));
         }
 
         console.timeEnd('ioredis incr');
     },
 
-	// ioredis get with pipeline
+    // ioredis incr with pipeline
     async () => {
         console.time('ioredis incr with pipeline');
 
         let len = TEST_LEN;
         let pipeline = ioredis.pipeline();
         while (len--) {
-            pipeline.get(`ioredis:${type}`);
+            pipeline.incr(`ioredis:${type}`);
         }
         await (pipeline.exec());
 
         console.timeEnd('ioredis incr with pipeline');
+    },
+
+    // ioredis incr with multi
+    async () => {
+        console.time('ioredis incr with multi');
+
+        let len = TEST_LEN;
+        let multi = ioredis.multi();
+        while (len--) {
+            multi.incr(`ioredis:${type}`);
+        }
+        await (multi.exec());
+
+        console.timeEnd('ioredis incr with multi');
     }
 ]);

--- a/benchmarks/keys.js
+++ b/benchmarks/keys.js
@@ -1,5 +1,5 @@
 module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
-	// node_redis keys
+    // node_redis keys
     async () => {
         console.time('node_redis keys');
 
@@ -13,7 +13,23 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('node_redis keys');
     },
 
-	// ioredis get
+    // node_redis get with multi
+    async () => {
+        console.time('node_redis keys with multi');
+
+        let len = TEST_LEN;
+        let multi = nodeRedis.multi();
+        while (len--) {
+            multi.keys(type);
+        }
+        await (new Promise(resolve => {
+            multi.exec(resolve);
+        }));
+
+        console.timeEnd('node_redis keys with multi');
+    },
+
+    // ioredis get
     async () => {
         console.time('ioredis keys');
 
@@ -25,7 +41,7 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('ioredis keys');
     },
 
-	// ioredis get with pipeline
+    // ioredis get with pipeline
     async () => {
         console.time('ioredis keys with pipeline');
 
@@ -37,5 +53,19 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         await (pipeline.exec());
 
         console.timeEnd('ioredis keys with pipeline');
+    },
+
+    // ioredis get with multi
+    async () => {
+        console.time('ioredis keys with multi');
+
+        let len = TEST_LEN;
+        let multi = ioredis.multi();
+        while (len--) {
+            multi.keys(type);
+        }
+        await (multi.exec());
+
+        console.timeEnd('ioredis keys with multi');
     }
 ]);

--- a/benchmarks/set.js
+++ b/benchmarks/set.js
@@ -1,5 +1,5 @@
 module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
-	// node_redis set
+    // node_redis set
     async () => {
         console.time('node_redis set');
 
@@ -13,7 +13,23 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('node_redis set');
     },
 
-	// ioredis set
+    // node_redis set with multi
+    async () => {
+        console.time('node_redis set with multi');
+
+        let len = TEST_LEN;
+        let multi = nodeRedis.multi();
+        while (len--) {
+            multi.set(`node_redis:${type}`, TEST_DATA.string);
+        }
+        await (new Promise(resolve => {
+            multi.exec(resolve);
+        }));
+
+        console.timeEnd('node_redis set with multi');
+    },
+
+    // ioredis set
     async () => {
         console.time('ioredis set');
 
@@ -25,7 +41,7 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         console.timeEnd('ioredis set');
     },
 
-	// ioredis set with pipeline
+    // ioredis set with pipeline
     async () => {
         console.time('ioredis set with pipeline');
 
@@ -37,5 +53,19 @@ module.exports = ({TEST_LEN, TEST_DATA, nodeRedis, ioredis, type}) => ([
         await (pipeline.exec());
 
         console.timeEnd('ioredis set with pipeline');
+    },
+
+    // ioredis set with multi
+    async () => {
+        console.time('ioredis set with multi');
+
+        let len = TEST_LEN;
+        let multi = ioredis.multi();
+        while (len--) {
+            multi.set(`ioredis:${type}`, TEST_DATA.string);
+        }
+        await (multi.exec());
+
+        console.timeEnd('ioredis set with multi');
     }
 ]);

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/poppinlp/node_redis-vs-ioredis#readme",
   "dependencies": {
-    "ioredis": "3.1.2",
-    "redis": "2.7.1"
+    "ioredis": "3.2.2",
+    "redis": "2.8.0"
   },
   "engines": {
     "node": ">= 6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@ cluster-key-slot@^1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.8.tgz#7654556085a65330932a2e8b5976f8e2d0b3e414"
 
-debug@^2.2.0:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -28,22 +28,97 @@ flexbuffer@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
 
-ioredis@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-3.1.2.tgz#2579e3eba6dc490f68f14c7b51346281332b467b"
+ioredis@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-3.2.2.tgz#b7d5ff3afd77bb9718bb2821329b894b9a44c00b"
   dependencies:
     bluebird "^3.3.4"
     cluster-key-slot "^1.0.6"
-    debug "^2.2.0"
+    debug "^2.6.9"
     denque "^1.1.0"
     flexbuffer "0.0.6"
-    lodash "^4.8.2"
+    lodash.assign "^4.2.0"
+    lodash.bind "^4.2.1"
+    lodash.clone "^4.5.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.defaults "^4.2.0"
+    lodash.difference "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.foreach "^4.5.0"
+    lodash.isempty "^4.4.0"
+    lodash.keys "^4.2.0"
+    lodash.noop "^3.0.1"
+    lodash.partial "^4.2.1"
+    lodash.pick "^4.4.0"
+    lodash.sample "^4.2.1"
+    lodash.shuffle "^4.2.0"
+    lodash.values "^4.3.0"
     redis-commands "^1.2.0"
     redis-parser "^2.4.0"
 
-lodash@^4.8.2:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
+lodash.bind@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
+
+lodash.clone@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
+
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.foreach@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+
+lodash.keys@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
+
+lodash.noop@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.noop/-/lodash.noop-3.0.1.tgz#38188f4d650a3a474258439b96ec45b32617133c"
+
+lodash.partial@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.partial/-/lodash.partial-4.2.1.tgz#49f3d8cfdaa3bff8b3a91d127e923245418961d4"
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.sample@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.sample/-/lodash.sample-4.2.1.tgz#5e4291b0c753fa1abeb0aab8fb29df1b66f07f6d"
+
+lodash.shuffle@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
+
+lodash.values@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
 
 ms@2.0.0:
   version "2.0.0"
@@ -53,14 +128,14 @@ redis-commands@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.1.tgz#81d826f45fa9c8b2011f4cd7a0fe597d241d442b"
 
-redis-parser@^2.4.0, redis-parser@^2.5.0:
+redis-parser@^2.4.0, redis-parser@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
 
-redis@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-2.7.1.tgz#7d56f7875b98b20410b71539f1d878ed58ebf46a"
+redis@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
   dependencies:
     double-ended-queue "^2.1.0-0"
     redis-commands "^1.2.0"
-    redis-parser "^2.5.0"
+    redis-parser "^2.6.0"


### PR DESCRIPTION
This will add benchmarks of MULTI command for node_redis and ioredis. It gives me pretty interesting results:

```
node_redis set: 1101.676ms
node_redis set with multi: 134.085ms
ioredis set: 1245.416ms
ioredis set with pipeline: 186.200ms
ioredis set with multi: 235.097ms
node_redis get: 1078.067ms
node_redis get with multi: 146.878ms
ioredis get: 1172.676ms
ioredis get with pipeline: 194.163ms
ioredis get with multi: 363.943ms
node_redis hmset: 1193.696ms
node_redis hmset with multi: 246.269ms
ioredis hmset: 1314.663ms
ioredis hmset with pipeline: 246.364ms
ioredis hmset with multi: 339.257ms
node_redis hgetall: 1202.337ms
node_redis hgetall with multi: 203.902ms
ioredis hgetall: 1225.616ms
ioredis hgetall with pipeline: 175.914ms
ioredis hgetall with multi: 334.243ms
node_redis incr: 1168.673ms
node_redis incr with multi: 88.579ms
ioredis incr: 1112.973ms
ioredis incr with pipeline: 125.968ms
ioredis incr with multi: 246.836ms
node_redis keys: 1158.931ms
node_redis keys with multi: 268.533ms
ioredis keys: 1276.350ms
ioredis keys with pipeline: 310.051ms
ioredis keys with multi: 357.399ms
```

My setup:

- OS: macOS 10.12.6
- Processor: 3.3 GHz Intel Core i7 (dual core)
- Memory: 16GiB
- Graphics: Intel Iris Graphics 550 1536 MB