### PR TITLE
Using latest Redis dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I have no malice for both libraries. Just wanna do a performance benchmark.
 
 1. Use `git clone git@github.com:poppinlp/node_redis-vs-ioredis.git` to clone this repo to local.
 1. Use `yarn` or `npm i` to install dependencies.
-1. Use `redis-server` to start redis server local with no password.
+1. Use `redis-server` to start redis server local with no password. (or `docker compose up -d`)
 1. Use `yarn benchmark` or `npm run benchmark` to start benchmark.
 
 ## Result

--- a/benchmark.js
+++ b/benchmark.js
@@ -35,7 +35,9 @@ args.forEach((el, i, arr) => {
 	}
 });
 
-const nodeRedis = NodeRedis.createClient(REDIS_CONFIG);
+const nodeRedis = NodeRedis.createClient(
+	`redis://${REDIS_CONFIG.host}:${REDIS_CONFIG.port}`
+);
 const ioredis = new IORedis(REDIS_CONFIG);
 
 const units = [
@@ -78,6 +80,7 @@ const runTests = async (TEST_LEN, TEST_DATA, output) => {
 
 (async () => {
 	try {
+		await nodeRedis.connect();
 		// warm up a bit first
 		await runTests(100, TEST_DATA, false);
 		// now go

--- a/benchmarks/get.js
+++ b/benchmarks/get.js
@@ -6,41 +6,40 @@ module.exports = ({ nodeRedis, ioredis, type }) => {
 		{
 			name: "node_redis get",
 			obj: "node_redis",
-			loop: () =>
-				new Promise(resolve => nodeRedis.get(NODE_REDIS_KEY, resolve))
+			loop: () => nodeRedis.get(NODE_REDIS_KEY),
 		},
 		{
 			name: "node_redis get with multi",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.multi = nodeRedis.multi()),
-			loop: ctx => ctx.multi.get(NODE_REDIS_KEY),
-			afterLoop: ctx => new Promise(resolve => ctx.multi.exec(resolve))
+			beforeLoop: (ctx) => (ctx.multi = nodeRedis.multi()),
+			loop: (ctx) => ctx.multi.get(NODE_REDIS_KEY),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "node_redis get with batch",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.batch = nodeRedis.batch()),
-			loop: ctx => ctx.batch.get(NODE_REDIS_KEY),
-			afterLoop: ctx => new Promise(resolve => ctx.batch.exec(resolve))
+			beforeLoop: (ctx) => (ctx.batch = nodeRedis.multi()),
+			loop: (ctx) => ctx.batch.get(NODE_REDIS_KEY),
+			afterLoop: (ctx) => ctx.batch.execAsPipeline(),
 		},
 		{
 			name: "ioredis get",
 			obj: "ioredis",
-			loop: () => ioredis.get(IOREDIS_KEY)
+			loop: () => ioredis.get(IOREDIS_KEY),
 		},
 		{
 			name: "ioredis get with multi",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.multi = ioredis.multi()),
-			loop: ctx => ctx.multi.get(IOREDIS_KEY),
-			afterLoop: ctx => ctx.multi.exec()
+			beforeLoop: (ctx) => (ctx.multi = ioredis.multi()),
+			loop: (ctx) => ctx.multi.get(IOREDIS_KEY),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "ioredis get with pipeline",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.pipeline = ioredis.pipeline()),
-			loop: ctx => ctx.pipeline.get(IOREDIS_KEY),
-			afterLoop: ctx => ctx.pipeline.exec()
-		}
+			beforeLoop: (ctx) => (ctx.pipeline = ioredis.pipeline()),
+			loop: (ctx) => ctx.pipeline.get(IOREDIS_KEY),
+			afterLoop: (ctx) => ctx.pipeline.exec(),
+		},
 	];
 };

--- a/benchmarks/hgetall.js
+++ b/benchmarks/hgetall.js
@@ -6,43 +6,40 @@ module.exports = ({ nodeRedis, ioredis, type }) => {
 		{
 			name: "node_redis hgetall",
 			obj: "node_redis",
-			loop: () =>
-				new Promise(resolve =>
-					nodeRedis.hgetall(NODE_REDIS_KEY, resolve)
-				)
+			loop: () => nodeRedis.hGetAll(NODE_REDIS_KEY),
 		},
 		{
 			name: "node_redis hgetall with multi",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.multi = nodeRedis.multi()),
-			loop: ctx => ctx.multi.hgetall(NODE_REDIS_KEY),
-			afterLoop: ctx => new Promise(resolve => ctx.multi.exec(resolve))
+			beforeLoop: (ctx) => (ctx.multi = nodeRedis.multi()),
+			loop: (ctx) => ctx.multi.hGetAll(NODE_REDIS_KEY),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "node_redis hgetall with batch",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.batch = nodeRedis.batch()),
-			loop: ctx => ctx.batch.hgetall(NODE_REDIS_KEY),
-			afterLoop: ctx => new Promise(resolve => ctx.batch.exec(resolve))
+			beforeLoop: (ctx) => (ctx.batch = nodeRedis.multi()),
+			loop: (ctx) => ctx.batch.hGetAll(NODE_REDIS_KEY),
+			afterLoop: (ctx) => ctx.batch.execAsPipeline(),
 		},
 		{
 			name: "ioredis hgetall",
 			obj: "ioredis",
-			loop: () => ioredis.hgetall(IOREDIS_KEY)
+			loop: () => ioredis.hgetall(IOREDIS_KEY),
 		},
 		{
 			name: "ioredis hgetall with multi",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.multi = ioredis.multi()),
-			loop: ctx => ctx.multi.hgetall(IOREDIS_KEY),
-			afterLoop: ctx => ctx.multi.exec()
+			beforeLoop: (ctx) => (ctx.multi = ioredis.multi()),
+			loop: (ctx) => ctx.multi.hgetall(IOREDIS_KEY),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "ioredis hgetall with pipeline",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.pipeline = ioredis.pipeline()),
-			loop: ctx => ctx.pipeline.hgetall(IOREDIS_KEY),
-			afterLoop: ctx => ctx.pipeline.exec()
-		}
+			beforeLoop: (ctx) => (ctx.pipeline = ioredis.pipeline()),
+			loop: (ctx) => ctx.pipeline.hgetall(IOREDIS_KEY),
+			afterLoop: (ctx) => ctx.pipeline.exec(),
+		},
 	];
 };

--- a/benchmarks/hmset.js
+++ b/benchmarks/hmset.js
@@ -6,43 +6,40 @@ module.exports = ({ TEST_DATA, nodeRedis, ioredis, type }) => {
 		{
 			name: "node_redis hmset",
 			obj: "node_redis",
-			loop: () =>
-				new Promise(resolve =>
-					nodeRedis.hmset(NODE_REDIS_KEY, TEST_DATA.hash, resolve)
-				)
+			loop: () => nodeRedis.hSet(NODE_REDIS_KEY, TEST_DATA.hash),
 		},
 		{
 			name: "node_redis hmset with multi",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.multi = nodeRedis.multi()),
-			loop: ctx => ctx.multi.hmset(NODE_REDIS_KEY, TEST_DATA.hash),
-			afterLoop: ctx => new Promise(resolve => ctx.multi.exec(resolve))
+			beforeLoop: (ctx) => (ctx.multi = nodeRedis.multi()),
+			loop: (ctx) => ctx.multi.hSet(NODE_REDIS_KEY, TEST_DATA.hash),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "node_redis hmset with batch",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.batch = nodeRedis.batch()),
-			loop: ctx => ctx.batch.hmset(NODE_REDIS_KEY, TEST_DATA.hash),
-			afterLoop: ctx => new Promise(resolve => ctx.batch.exec(resolve))
+			beforeLoop: (ctx) => (ctx.batch = nodeRedis.multi()),
+			loop: (ctx) => ctx.batch.hSet(NODE_REDIS_KEY, TEST_DATA.hash),
+			afterLoop: (ctx) => ctx.batch.execAsPipeline(),
 		},
 		{
 			name: "ioredis hmset",
 			obj: "ioredis",
-			loop: () => ioredis.hmset(IOREDIS_KEY, TEST_DATA.hash)
+			loop: () => ioredis.hmset(IOREDIS_KEY, TEST_DATA.hash),
 		},
 		{
 			name: "ioredis hmset with multi",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.multi = ioredis.multi()),
-			loop: ctx => ctx.multi.hmset(IOREDIS_KEY, TEST_DATA.hash),
-			afterLoop: ctx => ctx.multi.exec()
+			beforeLoop: (ctx) => (ctx.multi = ioredis.multi()),
+			loop: (ctx) => ctx.multi.hmset(IOREDIS_KEY, TEST_DATA.hash),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "ioredis hmset with pipeline",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.pipeline = ioredis.pipeline()),
-			loop: ctx => ctx.pipeline.hmset(IOREDIS_KEY, TEST_DATA.hash),
-			afterLoop: ctx => ctx.pipeline.exec()
-		}
+			beforeLoop: (ctx) => (ctx.pipeline = ioredis.pipeline()),
+			loop: (ctx) => ctx.pipeline.hmset(IOREDIS_KEY, TEST_DATA.hash),
+			afterLoop: (ctx) => ctx.pipeline.exec(),
+		},
 	];
 };

--- a/benchmarks/incr.js
+++ b/benchmarks/incr.js
@@ -6,41 +6,40 @@ module.exports = ({ nodeRedis, ioredis, type }) => {
 		{
 			name: "node_redis incr",
 			obj: "node_redis",
-			loop: () =>
-				new Promise(resolve => nodeRedis.incr(NODE_REDIS_KEY, resolve))
+			loop: () => nodeRedis.incr(NODE_REDIS_KEY),
 		},
 		{
 			name: "node_redis incr with multi",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.multi = nodeRedis.multi()),
-			loop: ctx => ctx.multi.incr(NODE_REDIS_KEY),
-			afterLoop: ctx => new Promise(resolve => ctx.multi.exec(resolve))
+			beforeLoop: (ctx) => (ctx.multi = nodeRedis.multi()),
+			loop: (ctx) => ctx.multi.incr(NODE_REDIS_KEY),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "node_redis incr with batch",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.batch = nodeRedis.batch()),
-			loop: ctx => ctx.batch.incr(NODE_REDIS_KEY),
-			afterLoop: ctx => new Promise(resolve => ctx.batch.exec(resolve))
+			beforeLoop: (ctx) => (ctx.batch = nodeRedis.multi()),
+			loop: (ctx) => ctx.batch.incr(NODE_REDIS_KEY),
+			afterLoop: (ctx) => ctx.batch.execAsPipeline(),
 		},
 		{
 			name: "ioredis incr",
 			obj: "ioredis",
-			loop: () => ioredis.incr(IOREDIS_KEY)
+			loop: () => ioredis.incr(IOREDIS_KEY),
 		},
 		{
 			name: "ioredis incr with multi",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.multi = ioredis.multi()),
-			loop: ctx => ctx.multi.incr(IOREDIS_KEY),
-			afterLoop: ctx => ctx.multi.exec()
+			beforeLoop: (ctx) => (ctx.multi = ioredis.multi()),
+			loop: (ctx) => ctx.multi.incr(IOREDIS_KEY),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "ioredis incr with pipeline",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.pipeline = ioredis.pipeline()),
-			loop: ctx => ctx.pipeline.incr(IOREDIS_KEY),
-			afterLoop: ctx => ctx.pipeline.exec()
-		}
+			beforeLoop: (ctx) => (ctx.pipeline = ioredis.pipeline()),
+			loop: (ctx) => ctx.pipeline.incr(IOREDIS_KEY),
+			afterLoop: (ctx) => ctx.pipeline.exec(),
+		},
 	];
 };

--- a/benchmarks/keys.js
+++ b/benchmarks/keys.js
@@ -6,41 +6,40 @@ module.exports = ({ nodeRedis, ioredis, type }) => {
 		{
 			name: "node_redis keys",
 			obj: "node_redis",
-			loop: () =>
-				new Promise(resolve => nodeRedis.keys(NODE_REDIS_KEY, resolve))
+			loop: () => nodeRedis.keys(NODE_REDIS_KEY),
 		},
 		{
 			name: "node_redis keys with multi",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.multi = nodeRedis.multi()),
-			loop: ctx => ctx.multi.keys(NODE_REDIS_KEY),
-			afterLoop: ctx => new Promise(resolve => ctx.multi.exec(resolve))
+			beforeLoop: (ctx) => (ctx.multi = nodeRedis.multi()),
+			loop: (ctx) => ctx.multi.keys(NODE_REDIS_KEY),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "node_redis keys with batch",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.batch = nodeRedis.batch()),
-			loop: ctx => ctx.batch.keys(NODE_REDIS_KEY),
-			afterLoop: ctx => new Promise(resolve => ctx.batch.exec(resolve))
+			beforeLoop: (ctx) => (ctx.batch = nodeRedis.multi()),
+			loop: (ctx) => ctx.batch.keys(NODE_REDIS_KEY),
+			afterLoop: (ctx) => ctx.batch.execAsPipeline(),
 		},
 		{
 			name: "ioredis keys",
 			obj: "ioredis",
-			loop: () => ioredis.keys(IOREDIS_KEY)
+			loop: () => ioredis.keys(IOREDIS_KEY),
 		},
 		{
 			name: "ioredis keys with multi",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.multi = ioredis.multi()),
-			loop: ctx => ctx.multi.keys(IOREDIS_KEY),
-			afterLoop: ctx => ctx.multi.exec()
+			beforeLoop: (ctx) => (ctx.multi = ioredis.multi()),
+			loop: (ctx) => ctx.multi.keys(IOREDIS_KEY),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "ioredis keys with pipeline",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.pipeline = ioredis.pipeline()),
-			loop: ctx => ctx.pipeline.keys(IOREDIS_KEY),
-			afterLoop: ctx => ctx.pipeline.exec()
-		}
+			beforeLoop: (ctx) => (ctx.pipeline = ioredis.pipeline()),
+			loop: (ctx) => ctx.pipeline.keys(IOREDIS_KEY),
+			afterLoop: (ctx) => ctx.pipeline.exec(),
+		},
 	];
 };

--- a/benchmarks/set.js
+++ b/benchmarks/set.js
@@ -6,43 +6,41 @@ module.exports = ({ TEST_DATA, nodeRedis, ioredis, type }) => {
 		{
 			name: "node_redis set",
 			obj: "node_redis",
-			loop: () =>
-				new Promise(resolve =>
-					nodeRedis.set(NODE_REDIS_KEY, TEST_DATA.string, resolve)
-				)
+			loop: () => nodeRedis.set(NODE_REDIS_KEY, TEST_DATA.string),
 		},
 		{
 			name: "node_redis set with multi",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.multi = nodeRedis.multi()),
-			loop: ctx => ctx.multi.set(NODE_REDIS_KEY, TEST_DATA.string),
-			afterLoop: ctx => new Promise(resolve => ctx.multi.exec(resolve))
+			beforeLoop: (ctx) => (ctx.multi = nodeRedis.multi()),
+			loop: (ctx) => ctx.multi.set(NODE_REDIS_KEY, TEST_DATA.string),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
+		// https://github.com/redis/node-redis/issues/1796
 		{
 			name: "node_redis set with batch",
 			obj: "node_redis",
-			beforeLoop: ctx => (ctx.batch = nodeRedis.batch()),
-			loop: ctx => ctx.batch.set(NODE_REDIS_KEY, TEST_DATA.string),
-			afterLoop: ctx => new Promise(resolve => ctx.batch.exec(resolve))
+			beforeLoop: (ctx) => (ctx.batch = nodeRedis.multi()),
+			loop: (ctx) => ctx.batch.set(NODE_REDIS_KEY, TEST_DATA.string),
+			afterLoop: (ctx) => ctx.batch.execAsPipeline(),
 		},
 		{
 			name: "ioredis set",
 			obj: "ioredis",
-			loop: () => ioredis.set(IOREDIS_KEY, TEST_DATA.string)
+			loop: () => ioredis.set(IOREDIS_KEY, TEST_DATA.string),
 		},
 		{
 			name: "ioredis set with multi",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.multi = ioredis.multi()),
-			loop: ctx => ctx.multi.set(IOREDIS_KEY, TEST_DATA.string),
-			afterLoop: ctx => ctx.multi.exec()
+			beforeLoop: (ctx) => (ctx.multi = ioredis.multi()),
+			loop: (ctx) => ctx.multi.set(IOREDIS_KEY, TEST_DATA.string),
+			afterLoop: (ctx) => ctx.multi.exec(),
 		},
 		{
 			name: "ioredis set with pipeline",
 			obj: "ioredis",
-			beforeLoop: ctx => (ctx.pipeline = ioredis.pipeline()),
-			loop: ctx => ctx.pipeline.set(IOREDIS_KEY, TEST_DATA.string),
-			afterLoop: ctx => ctx.pipeline.exec()
-		}
+			beforeLoop: (ctx) => (ctx.pipeline = ioredis.pipeline()),
+			loop: (ctx) => ctx.pipeline.set(IOREDIS_KEY, TEST_DATA.string),
+			afterLoop: (ctx) => ctx.pipeline.exec(),
+		},
 	];
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  redis:
+    image: "redis:6.2-alpine"
+    ports:
+      - "6379:6379"

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/poppinlp/node_redis-vs-ioredis#readme",
   "dependencies": {
-    "ioredis": "^4.17.3",
-    "redis": "3.0.2"
+    "ioredis": "^4.28.3",
+    "redis": "4.0.3"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 16"
   }
 }


### PR DESCRIPTION
Now the `node-redis` package seems to be actively updated.
so I changed some incompatible methods.

Here are the results I tested on my 2019 MacBook Pro (virtual 4 Cpu,  6G Mem):

- node-redis (avg): 9586.215ms
- ioredis (avg): 9488.689ms

|Operation|node-redis(ms)|node-redis with multi(ms)|node-redis with pipeline(ms)|
|---|---|---|---|
|set|26525.039|170.461|112.881|
|get|26334.277|252.904|183.610|
|hset|26461.201|224.977|133.728|
|hgetall|31394.670|389.773|306.851|
|incr|28580.127|206.482|116.846|
|keys|29647.691|772.989|737.362|

|Operation|ioredis(ms)|ioredis with multi(ms)|ioredis with pipeline(ms)|
|---|---|---|---|
|set|25684.449|260.598|173.958|
|get|25720.408|290.935|226.623|
|hmset|25857.690|338.286|200.380|
|hgetall|31666.897|480.690|380.761|
|incr|28392.304|257.203|150.187|
|keys|29061.574|915.112|738.331|


I'm also curious about the results in your dev env.
Thank you.